### PR TITLE
fix `implied_bounds_entailment` future compat lint

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -26,7 +26,7 @@ macro_rules! create_events {
             $($EventName:ident => $event_name:literal $event_method_name:ident,)+
         }
     )+) => {
-        pub trait MethodsForEvents<C: crate::component::Component>: Sized + crate::render::base::ElementUpdaterMut<C> {
+        pub trait MethodsForEvents<'er, C: crate::component::Component>: Sized + crate::render::base::ElementUpdaterMut<'er, C> {
             $(
                 create_methods_for_event_trait! {
                     $($event_method_name $EventName,)+

--- a/src/render/base/element.rs
+++ b/src/render/base/element.rs
@@ -14,20 +14,20 @@ use crate::{
     },
 };
 
-pub trait ElementUpdaterMut<C: Component> {
+pub trait ElementUpdaterMut<'er, C: Component> {
     fn element_updater(&self) -> &ElementUpdater<C>;
-    fn element_updater_mut(&mut self) -> &mut ElementUpdater<C>;
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C>;
 }
 
-impl<C, T> ElementUpdaterMut<C> for &mut T
+impl<'er, C, T> ElementUpdaterMut<'er, C> for &mut T
 where
     C: Component,
-    T: ElementUpdaterMut<C>,
+    T: ElementUpdaterMut<'er, C>,
 {
     fn element_updater(&self) -> &ElementUpdater<C> {
         (**self).element_updater()
     }
-    fn element_updater_mut(&mut self) -> &mut ElementUpdater<C> {
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C> {
         (**self).element_updater_mut()
     }
 }

--- a/src/render/base/events.rs
+++ b/src/render/base/events.rs
@@ -1,8 +1,13 @@
 use super::MethodsForEvents;
 
-impl<C: crate::component::Component, T> StateHelperMethods<C> for T where T: MethodsForEvents<C> {}
+impl<'er, C: crate::component::Component, T> StateHelperMethods<'er, C> for T where
+    T: MethodsForEvents<'er, C>
+{
+}
 
-pub trait StateHelperMethods<C: crate::component::Component>: MethodsForEvents<C> {
+pub trait StateHelperMethods<'er, C: crate::component::Component>:
+    MethodsForEvents<'er, C>
+{
     fn on_input_value(
         self,
         comp: &crate::Comp<C>,

--- a/src/render/base/nodes.rs
+++ b/src/render/base/nodes.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use wasm_bindgen::UnwrapThrowExt;
 
-pub trait NodesUpdaterMut<C: Component> {
-    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<C>;
+pub trait NodesUpdaterMut<'n, C: Component> {
+    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<'n, C>;
 }
 
 pub struct NodesUpdater<'a, C: Component> {

--- a/src/render/html/attributes.rs
+++ b/src/render/html/attributes.rs
@@ -103,8 +103,8 @@ make_traits_for_property_values! {
 /// with attribute value to help handle the issue. But this trait alone
 /// can not sovle the issue. We also need HtmlElementUpdater and
 /// HtmlNodesUpdater.
-pub trait MethodsForSelectedValueSelectedIndex<C: Component>:
-    Sized + HtmlElementUpdaterMut<C>
+pub trait MethodsForSelectedValueSelectedIndex<'er, C: Component>:
+    Sized + HtmlElementUpdaterMut<'er, C>
 {
     fn value(mut self, value: impl PropertyValue<C>) -> Self {
         value.render(self.html_element_updater_mut());
@@ -135,8 +135,8 @@ make_traits_for_property_values! {
     }
 }
 
-pub trait HamsHandMade<C: Component>:
-    Sized + ElementUpdaterMut<C> + HamsForDistinctNames<C>
+pub trait HamsHandMade<'er, C: Component>:
+    Sized + ElementUpdaterMut<'er, C> + HamsForDistinctNames<'er, C>
 {
     fn done(self) {}
 
@@ -384,64 +384,70 @@ impl<'er, C: Component> StaticAttributes<'er, C> {
     }
 }
 
-impl<'er, C: Component> ElementUpdaterMut<C> for AttributesOnly<'er, C> {
+impl<'er, C: Component> ElementUpdaterMut<'er, C> for AttributesOnly<'er, C> {
     fn element_updater(&self) -> &ElementUpdater<C> {
         self.0.element_updater()
     }
-    fn element_updater_mut(&mut self) -> &mut ElementUpdater<C> {
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C> {
         self.0.element_updater_mut()
     }
 }
-impl<'er, C: Component> HtmlElementUpdaterMut<C> for AttributesOnly<'er, C> {
-    fn html_element_updater_mut(&mut self) -> &'er mut HtmlElementUpdater<C> {
+impl<'er, C: Component> HtmlElementUpdaterMut<'er, C> for AttributesOnly<'er, C> {
+    fn html_element_updater_mut(&mut self) -> &mut HtmlElementUpdater<'er, C> {
         &mut self.0
     }
 }
 
-impl<'er, C: Component> ElementUpdaterMut<C> for StaticAttributesOnly<'er, C> {
+impl<'er, C: Component> ElementUpdaterMut<'er, C> for StaticAttributesOnly<'er, C> {
     fn element_updater(&self) -> &ElementUpdater<C> {
         self.0.element_updater()
     }
-    fn element_updater_mut(&mut self) -> &mut ElementUpdater<C> {
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C> {
         self.0.element_updater_mut()
     }
 }
-impl<'er, C: Component> HtmlElementUpdaterMut<C> for StaticAttributesOnly<'er, C> {
-    fn html_element_updater_mut(&mut self) -> &'er mut HtmlElementUpdater<C> {
+impl<'er, C: Component> HtmlElementUpdaterMut<'er, C> for StaticAttributesOnly<'er, C> {
+    fn html_element_updater_mut(&mut self) -> &mut HtmlElementUpdater<'er, C> {
         &mut self.0
     }
 }
 
-impl<'er, C: Component> ElementUpdaterMut<C> for StaticAttributes<'er, C> {
+impl<'er, C: Component> ElementUpdaterMut<'er, C> for StaticAttributes<'er, C> {
     fn element_updater(&self) -> &ElementUpdater<C> {
         self.0.element_updater()
     }
-    fn element_updater_mut(&mut self) -> &mut ElementUpdater<C> {
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C> {
         self.0.element_updater_mut()
     }
 }
-impl<'er, C: Component> HtmlElementUpdaterMut<C> for StaticAttributes<'er, C> {
-    fn html_element_updater_mut(&mut self) -> &'er mut HtmlElementUpdater<C> {
+impl<'er, C: Component> HtmlElementUpdaterMut<'er, C> for StaticAttributes<'er, C> {
+    fn html_element_updater_mut(&mut self) -> &mut HtmlElementUpdater<'er, C> {
         &mut self.0
     }
 }
 
-impl<'er, C: Component> MethodsForSelectedValueSelectedIndex<C> for HtmlElementUpdater<'er, C> {}
-impl<'er, C: Component> HamsHandMade<C> for HtmlElementUpdater<'er, C> {}
-impl<'er, C: Component> HamsForDistinctNames<C> for HtmlElementUpdater<'er, C> {}
+impl<'er, C: Component> MethodsForSelectedValueSelectedIndex<'er, C>
+    for HtmlElementUpdater<'er, C>
+{
+}
+impl<'er, C: Component> HamsHandMade<'er, C> for HtmlElementUpdater<'er, C> {}
+impl<'er, C: Component> HamsForDistinctNames<'er, C> for HtmlElementUpdater<'er, C> {}
 
-impl<'er, C: Component> MethodsForSelectedValueSelectedIndex<C> for StaticAttributes<'er, C> {}
-impl<'er, C: Component> HamsHandMade<C> for StaticAttributes<'er, C> {}
-impl<'er, C: Component> HamsForDistinctNames<C> for StaticAttributes<'er, C> {}
+impl<'er, C: Component> MethodsForSelectedValueSelectedIndex<'er, C> for StaticAttributes<'er, C> {}
+impl<'er, C: Component> HamsHandMade<'er, C> for StaticAttributes<'er, C> {}
+impl<'er, C: Component> HamsForDistinctNames<'er, C> for StaticAttributes<'er, C> {}
 
-impl<'er, C: Component> MethodsForSelectedValueSelectedIndex<C> for AttributesOnly<'er, C> {}
-impl<'er, C: Component> HamsHandMade<C> for AttributesOnly<'er, C> {}
-impl<'er, C: Component> HamsForDistinctNames<C> for AttributesOnly<'er, C> {}
+impl<'er, C: Component> MethodsForSelectedValueSelectedIndex<'er, C> for AttributesOnly<'er, C> {}
+impl<'er, C: Component> HamsHandMade<'er, C> for AttributesOnly<'er, C> {}
+impl<'er, C: Component> HamsForDistinctNames<'er, C> for AttributesOnly<'er, C> {}
 
-impl<'er, C: Component> MethodsForSelectedValueSelectedIndex<C> for StaticAttributesOnly<'er, C> {}
-impl<'er, C: Component> HamsHandMade<C> for StaticAttributesOnly<'er, C> {}
-impl<'er, C: Component> HamsForDistinctNames<C> for StaticAttributesOnly<'er, C> {}
+impl<'er, C: Component> MethodsForSelectedValueSelectedIndex<'er, C>
+    for StaticAttributesOnly<'er, C>
+{
+}
+impl<'er, C: Component> HamsHandMade<'er, C> for StaticAttributesOnly<'er, C> {}
+impl<'er, C: Component> HamsForDistinctNames<'er, C> for StaticAttributesOnly<'er, C> {}
 
-impl<'er, C: Component> MethodsForEvents<C> for StaticAttributes<'er, C> {}
-impl<'er, C: Component> MethodsForEvents<C> for StaticAttributesOnly<'er, C> {}
-impl<'er, C: Component> MethodsForEvents<C> for AttributesOnly<'er, C> {}
+impl<'er, C: Component> MethodsForEvents<'er, C> for StaticAttributes<'er, C> {}
+impl<'er, C: Component> MethodsForEvents<'er, C> for StaticAttributesOnly<'er, C> {}
+impl<'er, C: Component> MethodsForEvents<'er, C> for AttributesOnly<'er, C> {}

--- a/src/render/html/attributes_elements_with_ambiguous_names.rs
+++ b/src/render/html/attributes_elements_with_ambiguous_names.rs
@@ -35,18 +35,18 @@ make_trait_for_same_name_attribute_and_element_methods! {
 impl<'er, C: Component> HemsHamsAmbiguous for HtmlElementUpdater<'er, C> {}
 impl<'er, C: Component> HemsHamsAmbiguous for StaticAttributes<'er, C> {}
 
-impl<'er, C: Component> HamsForAmbiguousNames<C> for AttributesOnly<'er, C> {}
-impl<'er, C: Component> HamsForAmbiguousNames<C> for StaticAttributesOnly<'er, C> {}
+impl<'er, C: Component> HamsForAmbiguousNames<'er, C> for AttributesOnly<'er, C> {}
+impl<'er, C: Component> HamsForAmbiguousNames<'er, C> for StaticAttributesOnly<'er, C> {}
 
-impl<'n, C: Component> HemsForAmbiguousNames<C> for StaticNodesOwned<'n, C> {
+impl<'n, C: Component> HemsForAmbiguousNames<'n, C> for StaticNodesOwned<'n, C> {
     type Output = Self;
 }
-impl<'n, C: Component> HemsForAmbiguousNames<C> for NodesOwned<'n, C> {
+impl<'n, C: Component> HemsForAmbiguousNames<'n, C> for NodesOwned<'n, C> {
     type Output = Self;
 }
-impl<'h, 'n: 'h, C: Component> HemsForAmbiguousNames<C> for StaticNodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> HemsForAmbiguousNames<'n, C> for StaticNodes<'h, 'n, C> {
     type Output = Self;
 }
-impl<'h, 'n: 'h, C: Component> HemsForAmbiguousNames<C> for Nodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> HemsForAmbiguousNames<'n, C> for Nodes<'h, 'n, C> {
     type Output = Self;
 }

--- a/src/render/html/attributes_with_predefined_values.rs
+++ b/src/render/html/attributes_with_predefined_values.rs
@@ -234,7 +234,7 @@ TraitName: HamsWithPredefinedValues
 }
 }
 
-impl<'er, C: Component> HamsWithPredefinedValues<C> for HtmlElementUpdater<'er, C> {}
-impl<'er, C: Component> HamsWithPredefinedValues<C> for StaticAttributes<'er, C> {}
-impl<'er, C: Component> HamsWithPredefinedValues<C> for AttributesOnly<'er, C> {}
-impl<'er, C: Component> HamsWithPredefinedValues<C> for StaticAttributesOnly<'er, C> {}
+impl<'er, C: Component> HamsWithPredefinedValues<'er, C> for HtmlElementUpdater<'er, C> {}
+impl<'er, C: Component> HamsWithPredefinedValues<'er, C> for StaticAttributes<'er, C> {}
+impl<'er, C: Component> HamsWithPredefinedValues<'er, C> for AttributesOnly<'er, C> {}
+impl<'er, C: Component> HamsWithPredefinedValues<'er, C> for StaticAttributesOnly<'er, C> {}

--- a/src/render/html/element.rs
+++ b/src/render/html/element.rs
@@ -58,8 +58,8 @@ impl Drop for SelectElementValueManager {
     }
 }
 
-pub trait HtmlElementUpdaterMut<C: Component> {
-    fn html_element_updater_mut(&mut self) -> &mut HtmlElementUpdater<C>;
+pub trait HtmlElementUpdaterMut<'er, C: Component> {
+    fn html_element_updater_mut(&mut self) -> &mut HtmlElementUpdater<'er, C>;
 }
 
 /// This struct helps rendering the element's attributes and its child nodes.
@@ -72,18 +72,18 @@ pub struct HtmlElementUpdater<'er, C: Component> {
     select_element_value_manager: Option<SelectElementValueManager>,
 }
 
-impl<'er, C: Component> ElementUpdaterMut<C> for HtmlElementUpdater<'er, C> {
+impl<'er, C: Component> ElementUpdaterMut<'er, C> for HtmlElementUpdater<'er, C> {
     fn element_updater(&self) -> &ElementUpdater<C> {
         &self.element_updater
     }
 
-    fn element_updater_mut(&mut self) -> &'er mut ElementUpdater<C> {
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C> {
         &mut self.element_updater
     }
 }
 
-impl<'er, C: Component> HtmlElementUpdaterMut<C> for HtmlElementUpdater<'er, C> {
-    fn html_element_updater_mut(&mut self) -> &'er mut HtmlElementUpdater<C> {
+impl<'er, C: Component> HtmlElementUpdaterMut<'er, C> for HtmlElementUpdater<'er, C> {
+    fn html_element_updater_mut(&mut self) -> &mut HtmlElementUpdater<'er, C> {
         self
     }
 }
@@ -221,4 +221,4 @@ impl<'er, C: Component> HtmlElementUpdater<'er, C> {
     }
 }
 
-impl<'er, C: Component> MethodsForEvents<C> for HtmlElementUpdater<'er, C> {}
+impl<'er, C: Component> MethodsForEvents<'er, C> for HtmlElementUpdater<'er, C> {}

--- a/src/render/html/keyed_list.rs
+++ b/src/render/html/keyed_list.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 pub trait HemsForKeyedList<'a, C: Component>:
-    Sized + ElementUpdaterMut<C> + MakeNodesExtensions<'a>
+    Sized + ElementUpdaterMut<'a, C> + MakeNodesExtensions<'a>
 {
     fn keyed_list_with_render<I, II, G, K, R>(
         mut self,

--- a/src/render/html/list.rs
+++ b/src/render/html/list.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 pub trait HemsForList<'a, C: Component>:
-    Sized + ElementUpdaterMut<C> + MakeNodesExtensions<'a>
+    Sized + ElementUpdaterMut<'a, C> + MakeNodesExtensions<'a>
 {
     fn list_with_render<I, II, R>(
         mut self,

--- a/src/render/html/nodes.rs
+++ b/src/render/html/nodes.rs
@@ -23,14 +23,14 @@ pub struct HtmlNodesUpdater<'n, C: Component> {
     _select_element_value_manager: Option<SelectElementValueManager>,
 }
 
-impl<'n, C: Component> NodesUpdaterMut<C> for HtmlNodesUpdater<'n, C> {
-    fn nodes_updater_mut(&mut self) -> &'n mut NodesUpdater<C> {
+impl<'n, C: Component> NodesUpdaterMut<'n, C> for HtmlNodesUpdater<'n, C> {
+    fn nodes_updater_mut<'a>(self: &'a mut HtmlNodesUpdater<'n, C>) -> &'a mut NodesUpdater<'n, C> {
         &mut self.nodes_updater
     }
 }
 
-pub trait HemsHandMade<C: Component>: Sized {
-    type Output: From<Self> + NodesUpdaterMut<C>;
+pub trait HemsHandMade<'n, C: Component>: Sized {
+    type Output: From<Self> + NodesUpdaterMut<'n, C>;
 
     fn line_break(self) -> Self::Output {
         let mut this: Self::Output = self.into();
@@ -118,10 +118,10 @@ pub trait HemsHandMade<C: Component>: Sized {
     }
 }
 
-pub trait UpdateHtmlElement<C, O>: Sized
+pub trait UpdateHtmlElement<'n, C, O>: Sized
 where
     C: Component,
-    O: From<Self> + NodesUpdaterMut<C>,
+    O: From<Self> + NodesUpdaterMut<'n, C>,
 {
     fn render_element(
         self,
@@ -231,26 +231,26 @@ impl<'h, 'n: 'h, C: Component> StaticNodes<'h, 'n, C> {
     }
 }
 
-impl<'n, C: Component> NodesUpdaterMut<C> for NodesOwned<'n, C> {
-    fn nodes_updater_mut(&mut self) -> &'n mut NodesUpdater<C> {
+impl<'n, C: Component> NodesUpdaterMut<'n, C> for NodesOwned<'n, C> {
+    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<'n, C> {
         &mut self.0.nodes_updater
     }
 }
 
-impl<'n, C: Component> NodesUpdaterMut<C> for StaticNodesOwned<'n, C> {
-    fn nodes_updater_mut(&mut self) -> &'n mut NodesUpdater<C> {
+impl<'n, C: Component> NodesUpdaterMut<'n, C> for StaticNodesOwned<'n, C> {
+    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<'n, C> {
         &mut self.0.nodes_updater
     }
 }
 
-impl<'h, 'n: 'h, C: Component> NodesUpdaterMut<C> for Nodes<'h, 'n, C> {
-    fn nodes_updater_mut(&mut self) -> &'n mut NodesUpdater<C> {
+impl<'h, 'n: 'h, C: Component> NodesUpdaterMut<'n, C> for Nodes<'h, 'n, C> {
+    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<'n, C> {
         &mut self.0.nodes_updater
     }
 }
 
-impl<'h, 'n: 'h, C: Component> NodesUpdaterMut<C> for StaticNodes<'h, 'n, C> {
-    fn nodes_updater_mut(&mut self) -> &'n mut NodesUpdater<C> {
+impl<'h, 'n: 'h, C: Component> NodesUpdaterMut<'n, C> for StaticNodes<'h, 'n, C> {
+    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<'n, C> {
         &mut self.0.nodes_updater
     }
 }
@@ -338,7 +338,7 @@ impl<'n, C: Component> From<StaticAttributes<'n, C>> for StaticNodesOwned<'n, C>
 }
 
 pub trait MethodsForHtmlElementContent<'n, C: Component>:
-    ElementUpdaterMut<C> + Into<NodesOwned<'n, C>> + Into<StaticNodesOwned<'n, C>>
+    ElementUpdaterMut<'n, C> + Into<NodesOwned<'n, C>> + Into<StaticNodesOwned<'n, C>>
 {
     fn update_nodes(self) -> NodesOwned<'n, C> {
         self.into()
@@ -508,53 +508,59 @@ impl<'n, C: Component> StaticNodesOwned<'n, C> {
     }
 }
 
-impl<'h, 'n: 'h, C: Component> UpdateHtmlElement<C, Nodes<'h, 'n, C>> for Nodes<'h, 'n, C> {}
-impl<'h, 'n: 'h, C: Component> UpdateHtmlElement<C, StaticNodes<'h, 'n, C>>
+impl<'h, 'n: 'h, C: Component> UpdateHtmlElement<'n, C, Nodes<'h, 'n, C>> for Nodes<'h, 'n, C> {}
+impl<'h, 'n: 'h, C: Component> UpdateHtmlElement<'n, C, StaticNodes<'h, 'n, C>>
     for StaticNodes<'h, 'n, C>
 {
 }
-impl<'n, C: Component> UpdateHtmlElement<C, NodesOwned<'n, C>> for NodesOwned<'n, C> {}
-impl<'n, C: Component> UpdateHtmlElement<C, StaticNodesOwned<'n, C>> for StaticNodesOwned<'n, C> {}
-
-impl<'h, 'n: 'h, C: Component> HemsHandMade<C> for Nodes<'h, 'n, C> {
-    type Output = Self;
-}
-impl<'h, 'n: 'h, C: Component> HemsHandMade<C> for StaticNodes<'h, 'n, C> {
-    type Output = Self;
-}
-impl<'n, C: Component> HemsHandMade<C> for NodesOwned<'n, C> {
-    type Output = Self;
-}
-impl<'n, C: Component> HemsHandMade<C> for StaticNodesOwned<'n, C> {
-    type Output = Self;
+impl<'n, C: Component> UpdateHtmlElement<'n, C, NodesOwned<'n, C>> for NodesOwned<'n, C> {}
+impl<'n, C: Component> UpdateHtmlElement<'n, C, StaticNodesOwned<'n, C>>
+    for StaticNodesOwned<'n, C>
+{
 }
 
-impl<'h, 'n: 'h, C: Component> HemsForDistinctNames<C> for Nodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> HemsHandMade<'n, C> for Nodes<'h, 'n, C> {
     type Output = Self;
 }
-impl<'h, 'n: 'h, C: Component> HemsForDistinctNames<C> for StaticNodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> HemsHandMade<'n, C> for StaticNodes<'h, 'n, C> {
     type Output = Self;
 }
-impl<'n, C: Component> HemsForDistinctNames<C> for NodesOwned<'n, C> {
+impl<'n, C: Component> HemsHandMade<'n, C> for NodesOwned<'n, C> {
     type Output = Self;
 }
-impl<'n, C: Component> HemsForDistinctNames<C> for StaticNodesOwned<'n, C> {
+impl<'n, C: Component> HemsHandMade<'n, C> for StaticNodesOwned<'n, C> {
     type Output = Self;
 }
 
-impl<'er, C: Component> UpdateHtmlElement<C, NodesOwned<'er, C>> for HtmlElementUpdater<'er, C> {}
-impl<'er, C: Component> HemsHandMade<C> for HtmlElementUpdater<'er, C> {
+impl<'h, 'n: 'h, C: Component> HemsForDistinctNames<'n, C> for Nodes<'h, 'n, C> {
+    type Output = Self;
+}
+impl<'h, 'n: 'h, C: Component> HemsForDistinctNames<'n, C> for StaticNodes<'h, 'n, C> {
+    type Output = Self;
+}
+impl<'n, C: Component> HemsForDistinctNames<'n, C> for NodesOwned<'n, C> {
+    type Output = Self;
+}
+impl<'n, C: Component> HemsForDistinctNames<'n, C> for StaticNodesOwned<'n, C> {
+    type Output = Self;
+}
+
+impl<'er, C: Component> UpdateHtmlElement<'er, C, NodesOwned<'er, C>>
+    for HtmlElementUpdater<'er, C>
+{
+}
+impl<'er, C: Component> HemsHandMade<'er, C> for HtmlElementUpdater<'er, C> {
     type Output = NodesOwned<'er, C>;
 }
-impl<'er, C: Component> HemsForDistinctNames<C> for HtmlElementUpdater<'er, C> {
+impl<'er, C: Component> HemsForDistinctNames<'er, C> for HtmlElementUpdater<'er, C> {
     type Output = NodesOwned<'er, C>;
 }
 
-impl<'er, C: Component> UpdateHtmlElement<C, NodesOwned<'er, C>> for StaticAttributes<'er, C> {}
-impl<'er, C: Component> HemsHandMade<C> for StaticAttributes<'er, C> {
+impl<'er, C: Component> UpdateHtmlElement<'er, C, NodesOwned<'er, C>> for StaticAttributes<'er, C> {}
+impl<'er, C: Component> HemsHandMade<'er, C> for StaticAttributes<'er, C> {
     type Output = NodesOwned<'er, C>;
 }
-impl<'er, C: Component> HemsForDistinctNames<C> for StaticAttributes<'er, C> {
+impl<'er, C: Component> HemsForDistinctNames<'er, C> for StaticAttributes<'er, C> {
     type Output = NodesOwned<'er, C>;
 }
 

--- a/src/render/html/partial_list.rs
+++ b/src/render/html/partial_list.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-pub trait HemsForPartialList<'a, C: Component>: Sized + NodesUpdaterMut<C> {
+pub trait HemsForPartialList<'a, C: Component>: Sized + NodesUpdaterMut<'a, C> {
     fn list_with_render<I, II, R>(
         mut self,
         items: II,
@@ -59,5 +59,5 @@ pub trait HemsForPartialList<'a, C: Component>: Sized + NodesUpdaterMut<C> {
 
 impl<'a, C: Component> HemsForPartialList<'a, C> for NodesOwned<'a, C> {}
 impl<'a, C: Component> HemsForPartialList<'a, C> for StaticNodesOwned<'a, C> {}
-impl<'h, 'n: 'h, C: Component> HemsForPartialList<'h, C> for Nodes<'h, 'n, C> {}
-impl<'h, 'n: 'h, C: Component> HemsForPartialList<'h, C> for StaticNodes<'h, 'n, C> {}
+impl<'h, 'n: 'h, C: Component> HemsForPartialList<'n, C> for Nodes<'h, 'n, C> {}
+impl<'h, 'n: 'h, C: Component> HemsForPartialList<'n, C> for StaticNodes<'h, 'n, C> {}

--- a/src/render/macros/attributes.rs
+++ b/src/render/macros/attributes.rs
@@ -12,7 +12,7 @@ macro_rules! make_trait_for_attribute_methods {
             names: $($method_name)+
         }
 
-        pub trait $TraitName<C: Component>: Sized + crate::render::base::ElementUpdaterMut<C>
+        pub trait $TraitName<'er, C: Component>: Sized + crate::render::base::ElementUpdaterMut<'er, C>
         {$(
             make_trait_for_attribute_methods! {
                 @each
@@ -97,7 +97,7 @@ macro_rules! make_trait_for_attributes_with_predefined_values {
                 names: $($attribute_method_name)*
             })+
         );
-        pub trait $TraitName<C: Component>: Sized + crate::render::base::ElementUpdaterMut<C> {
+        pub trait $TraitName<'er, C: Component>: Sized + crate::render::base::ElementUpdaterMut<'er, C> {
             $(
             $(
                 make_trait_for_attributes_with_predefined_values!(
@@ -229,11 +229,11 @@ macro_rules! make_traits_for_attribute_values {
     ) => {
         $(
             pub trait $AttributeTrait<C: Component> {
-                fn render(self, name: &'static str, element: impl crate::render::base::ElementUpdaterMut<C>);
+                fn render<'a>(self, name: &'static str, element: impl crate::render::base::ElementUpdaterMut<'a, C>);
             }
             $(
                 impl<C: Component> $AttributeTrait<C> for $attribute_type {
-                    fn render(self, name: &'static str, mut element: impl crate::render::base::ElementUpdaterMut<C>) {
+                    fn render<'a>(self, name: &'static str, mut element: impl crate::render::base::ElementUpdaterMut<'a, C>) {
                         element.element_updater_mut().$method_name(name, self);
                     }
                 }
@@ -258,19 +258,19 @@ macro_rules! make_traits_for_attribute_values {
     ) => {
         #[cfg(feature = "queue-render")]
         impl<C: Component> $AttributeTrait<C> for &crate::queue_render::val::QrVal<$attribute_type> {
-            fn render(self, name: &'static str, mut element: impl crate::render::base::ElementUpdaterMut<C>) {
+            fn render<'a>(self, name: &'static str, mut element: impl crate::render::base::ElementUpdaterMut<'a, C>) {
                 element.element_updater_mut().$queue_render_method_name(name, self);
             }
         }
         #[cfg(feature = "queue-render")]
         impl<C: Component, T: 'static> $AttributeTrait<C> for crate::queue_render::val::QrValMap<T, $attribute_type> {
-            fn render(self, name: &'static str, mut element: impl crate::render::base::ElementUpdaterMut<C>) {
+            fn render<'a>(self, name: &'static str, mut element: impl crate::render::base::ElementUpdaterMut<'a, C>) {
                 element.element_updater_mut().$qrm_method_name(name, self);
             }
         }
         #[cfg(feature = "queue-render")]
         impl<C: Component, T: 'static> $AttributeTrait<C> for crate::queue_render::val::QrValMapWithState<C, T, $attribute_type> {
-            fn render(self, name: &'static str, mut element: impl crate::render::base::ElementUpdaterMut<C>) {
+            fn render<'a>(self, name: &'static str, mut element: impl crate::render::base::ElementUpdaterMut<'a, C>) {
                 element.element_updater_mut().$qrmws_method_name(name, self);
             }
         }

--- a/src/render/macros/elements.rs
+++ b/src/render/macros/elements.rs
@@ -88,8 +88,8 @@ macro_rules! make_trait_for_element_methods {
             names: $($method_name)+
         }
 
-        pub trait $TraitName<C: Component>: Sized + $UpdateElementTraitName<C, Self::Output> {
-            type Output: From<Self> + NodesUpdaterMut<C>;
+        pub trait $TraitName<'n, C: Component>: Sized + $UpdateElementTraitName<'n, C, Self::Output> {
+            type Output: From<Self> + NodesUpdaterMut<'n, C>;
             $(
             // fn $tag(self, element_updater: impl FnOnce($ElementUpdaterType<C>)) -> Self::Output {
             //     self.render_element(stringify!($tag), element_updater)

--- a/src/render/svg/attributes.rs
+++ b/src/render/svg/attributes.rs
@@ -13,7 +13,7 @@ make_traits_for_attribute_values! {
     }
 }
 
-pub trait SamsHandMade<C: Component>: Sized + ElementUpdaterMut<C> {
+pub trait SamsHandMade<'er, C: Component>: Sized + ElementUpdaterMut<'er, C> {
     fn class(mut self, class_name: &str) -> Self {
         self.element_updater_mut().class(class_name);
         self
@@ -375,41 +375,41 @@ impl<'er, C: Component> SvgStaticAttributes<'er, C> {
     }
 }
 
-impl<'er, C: Component> ElementUpdaterMut<C> for SvgAttributesOnly<'er, C> {
+impl<'er, C: Component> ElementUpdaterMut<'er, C> for SvgAttributesOnly<'er, C> {
     fn element_updater(&self) -> &ElementUpdater<C> {
         &self.0
     }
-    fn element_updater_mut(&mut self) -> &'er mut ElementUpdater<C> {
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C> {
         &mut self.0
     }
 }
 
-impl<'er, C: Component> ElementUpdaterMut<C> for SvgStaticAttributesOnly<'er, C> {
+impl<'er, C: Component> ElementUpdaterMut<'er, C> for SvgStaticAttributesOnly<'er, C> {
     fn element_updater(&self) -> &ElementUpdater<C> {
         &self.0
     }
-    fn element_updater_mut(&mut self) -> &'er mut ElementUpdater<C> {
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C> {
         &mut self.0
     }
 }
 
-impl<'er, C: Component> ElementUpdaterMut<C> for SvgStaticAttributes<'er, C> {
+impl<'er, C: Component> ElementUpdaterMut<'er, C> for SvgStaticAttributes<'er, C> {
     fn element_updater(&self) -> &ElementUpdater<C> {
         &self.0
     }
-    fn element_updater_mut(&mut self) -> &'er mut ElementUpdater<C> {
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C> {
         &mut self.0
     }
 }
 
-impl<'er, C: Component> SamsHandMade<C> for SvgElementUpdater<'er, C> {}
-impl<'er, C: Component> SamsForDistinctNames<C> for SvgElementUpdater<'er, C> {}
+impl<'er, C: Component> SamsHandMade<'er, C> for SvgElementUpdater<'er, C> {}
+impl<'er, C: Component> SamsForDistinctNames<'er, C> for SvgElementUpdater<'er, C> {}
 
-impl<'er, C: Component> SamsForDistinctNames<C> for SvgStaticAttributes<'er, C> {}
-impl<'er, C: Component> SamsHandMade<C> for SvgStaticAttributes<'er, C> {}
+impl<'er, C: Component> SamsForDistinctNames<'er, C> for SvgStaticAttributes<'er, C> {}
+impl<'er, C: Component> SamsHandMade<'er, C> for SvgStaticAttributes<'er, C> {}
 
-impl<'er, C: Component> SamsForDistinctNames<C> for SvgStaticAttributesOnly<'er, C> {}
-impl<'er, C: Component> SamsHandMade<C> for SvgStaticAttributesOnly<'er, C> {}
+impl<'er, C: Component> SamsForDistinctNames<'er, C> for SvgStaticAttributesOnly<'er, C> {}
+impl<'er, C: Component> SamsHandMade<'er, C> for SvgStaticAttributesOnly<'er, C> {}
 
-impl<'er, C: Component> SamsForDistinctNames<C> for SvgAttributesOnly<'er, C> {}
-impl<'er, C: Component> SamsHandMade<C> for SvgAttributesOnly<'er, C> {}
+impl<'er, C: Component> SamsForDistinctNames<'er, C> for SvgAttributesOnly<'er, C> {}
+impl<'er, C: Component> SamsHandMade<'er, C> for SvgAttributesOnly<'er, C> {}

--- a/src/render/svg/attributes_elements_with_ambiguous_names.rs
+++ b/src/render/svg/attributes_elements_with_ambiguous_names.rs
@@ -32,18 +32,18 @@ make_trait_for_same_name_attribute_and_element_methods! {
 impl<'er, C: Component> SemsSamsAmbiguous for SvgElementUpdater<'er, C> {}
 impl<'er, C: Component> SemsSamsAmbiguous for SvgStaticAttributes<'er, C> {}
 
-impl<'er, C: Component> SamsForAmbiguousNames<C> for SvgAttributesOnly<'er, C> {}
-impl<'er, C: Component> SamsForAmbiguousNames<C> for SvgStaticAttributesOnly<'er, C> {}
+impl<'er, C: Component> SamsForAmbiguousNames<'er, C> for SvgAttributesOnly<'er, C> {}
+impl<'er, C: Component> SamsForAmbiguousNames<'er, C> for SvgStaticAttributesOnly<'er, C> {}
 
-impl<'n, C: Component> SemsForAmbiguousNames<C> for SvgStaticNodesOwned<'n, C> {
+impl<'n, C: Component> SemsForAmbiguousNames<'n, C> for SvgStaticNodesOwned<'n, C> {
     type Output = Self;
 }
-impl<'n, C: Component> SemsForAmbiguousNames<C> for SvgNodesOwned<'n, C> {
+impl<'n, C: Component> SemsForAmbiguousNames<'n, C> for SvgNodesOwned<'n, C> {
     type Output = Self;
 }
-impl<'h, 'n: 'h, C: Component> SemsForAmbiguousNames<C> for SvgStaticNodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> SemsForAmbiguousNames<'n, C> for SvgStaticNodes<'h, 'n, C> {
     type Output = Self;
 }
-impl<'h, 'n: 'h, C: Component> SemsForAmbiguousNames<C> for SvgNodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> SemsForAmbiguousNames<'n, C> for SvgNodes<'h, 'n, C> {
     type Output = Self;
 }

--- a/src/render/svg/element.rs
+++ b/src/render/svg/element.rs
@@ -13,11 +13,11 @@ impl<'er, C: Component> From<ElementUpdater<'er, C>> for SvgElementUpdater<'er, 
     }
 }
 
-impl<'er, C: Component> ElementUpdaterMut<C> for SvgElementUpdater<'er, C> {
+impl<'er, C: Component> ElementUpdaterMut<'er, C> for SvgElementUpdater<'er, C> {
     fn element_updater(&self) -> &ElementUpdater<C> {
         &self.0
     }
-    fn element_updater_mut(&mut self) -> &'er mut ElementUpdater<C> {
+    fn element_updater_mut(&mut self) -> &mut ElementUpdater<'er, C> {
         &mut self.0
     }
 }

--- a/src/render/svg/keyed_list.rs
+++ b/src/render/svg/keyed_list.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub trait SemsForKeyedList<'a, C: Component>:
-    Sized + ElementUpdaterMut<C> + MakeNodesExtensions<'a>
+    Sized + ElementUpdaterMut<'a, C> + MakeNodesExtensions<'a>
 {
     fn keyed_list_with_render<I, II, G, K, R>(
         mut self,

--- a/src/render/svg/list.rs
+++ b/src/render/svg/list.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub trait SemsForList<'a, C: Component>:
-    Sized + ElementUpdaterMut<C> + MakeNodesExtensions<'a>
+    Sized + ElementUpdaterMut<'a, C> + MakeNodesExtensions<'a>
 {
     fn list_with_render<I, II, R>(
         mut self,

--- a/src/render/svg/nodes.rs
+++ b/src/render/svg/nodes.rs
@@ -13,10 +13,10 @@ use crate::{
 #[cfg(feature = "queue-render")]
 use crate::queue_render::val::QrVal;
 
-pub trait UpdateSvgElement<C, O>: Sized
+pub trait UpdateSvgElement<'n, C, O>: Sized
 where
     C: Component,
-    O: From<Self> + NodesUpdaterMut<C>,
+    O: From<Self> + NodesUpdaterMut<'n, C>,
 {
     fn render_element(
         self,
@@ -34,8 +34,8 @@ where
     }
 }
 
-pub trait SemsHandMade<C: Component>: Sized {
-    type Output: From<Self> + NodesUpdaterMut<C>;
+pub trait SemsHandMade<'n, C: Component>: Sized {
+    type Output: From<Self> + NodesUpdaterMut<'n, C>;
     fn match_if(self, f: impl FnOnce(SvgMatchIfUpdater<C>)) -> Self::Output {
         let mut this: Self::Output = self.into();
         let render = this.nodes_updater_mut();
@@ -233,26 +233,26 @@ impl<'h, 'n: 'h, C: Component> From<SvgStaticNodes<'h, 'n, C>> for SvgNodes<'h, 
     }
 }
 
-impl<'n, C: Component> NodesUpdaterMut<C> for SvgNodesOwned<'n, C> {
-    fn nodes_updater_mut(&mut self) -> &'n mut NodesUpdater<C> {
+impl<'n, C: Component> NodesUpdaterMut<'n, C> for SvgNodesOwned<'n, C> {
+    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<'n, C> {
         &mut self.0
     }
 }
 
-impl<'n, C: Component> NodesUpdaterMut<C> for SvgStaticNodesOwned<'n, C> {
-    fn nodes_updater_mut(&mut self) -> &'n mut NodesUpdater<C> {
+impl<'n, C: Component> NodesUpdaterMut<'n, C> for SvgStaticNodesOwned<'n, C> {
+    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<'n, C> {
         &mut self.0
     }
 }
 
-impl<'h, 'n: 'h, C: Component> NodesUpdaterMut<C> for SvgNodes<'h, 'n, C> {
-    fn nodes_updater_mut(&mut self) -> &'n mut NodesUpdater<C> {
+impl<'h, 'n: 'h, C: Component> NodesUpdaterMut<'n, C> for SvgNodes<'h, 'n, C> {
+    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<'n, C> {
         self.0
     }
 }
 
-impl<'h, 'n: 'h, C: Component> NodesUpdaterMut<C> for SvgStaticNodes<'h, 'n, C> {
-    fn nodes_updater_mut(&mut self) -> &'n mut NodesUpdater<C> {
+impl<'h, 'n: 'h, C: Component> NodesUpdaterMut<'n, C> for SvgStaticNodes<'h, 'n, C> {
+    fn nodes_updater_mut(&mut self) -> &mut NodesUpdater<'n, C> {
         self.0
     }
 }
@@ -270,49 +270,55 @@ impl<'n, C: Component> From<SvgStaticAttributes<'n, C>> for SvgNodesOwned<'n, C>
     }
 }
 
-impl<'n, C: Component> UpdateSvgElement<C, SvgNodesOwned<'n, C>> for SvgElementUpdater<'n, C> {}
-impl<'n, C: Component> UpdateSvgElement<C, SvgNodesOwned<'n, C>> for SvgStaticAttributes<'n, C> {}
+impl<'n, C: Component> UpdateSvgElement<'n, C, SvgNodesOwned<'n, C>> for SvgElementUpdater<'n, C> {}
+impl<'n, C: Component> UpdateSvgElement<'n, C, SvgNodesOwned<'n, C>>
+    for SvgStaticAttributes<'n, C>
+{
+}
 
-impl<'h, 'n: 'h, C: Component> UpdateSvgElement<C, SvgNodes<'h, 'n, C>> for SvgNodes<'h, 'n, C> {}
-impl<'h, 'n: 'h, C: Component> UpdateSvgElement<C, SvgStaticNodes<'h, 'n, C>>
+impl<'h, 'n: 'h, C: Component> UpdateSvgElement<'n, C, SvgNodes<'h, 'n, C>>
+    for SvgNodes<'h, 'n, C>
+{
+}
+impl<'h, 'n: 'h, C: Component> UpdateSvgElement<'n, C, SvgStaticNodes<'h, 'n, C>>
     for SvgStaticNodes<'h, 'n, C>
 {
 }
-impl<'n, C: Component> UpdateSvgElement<C, SvgNodesOwned<'n, C>> for SvgNodesOwned<'n, C> {}
-impl<'n, C: Component> UpdateSvgElement<C, SvgStaticNodesOwned<'n, C>>
+impl<'n, C: Component> UpdateSvgElement<'n, C, SvgNodesOwned<'n, C>> for SvgNodesOwned<'n, C> {}
+impl<'n, C: Component> UpdateSvgElement<'n, C, SvgStaticNodesOwned<'n, C>>
     for SvgStaticNodesOwned<'n, C>
 {
 }
 
-impl<'h, 'n: 'h, C: Component> SemsHandMade<C> for SvgNodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> SemsHandMade<'n, C> for SvgNodes<'h, 'n, C> {
     type Output = Self;
 }
-impl<'h, 'n: 'h, C: Component> SemsHandMade<C> for SvgStaticNodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> SemsHandMade<'n, C> for SvgStaticNodes<'h, 'n, C> {
     type Output = Self;
 }
-impl<'n, C: Component> SemsHandMade<C> for SvgNodesOwned<'n, C> {
+impl<'n, C: Component> SemsHandMade<'n, C> for SvgNodesOwned<'n, C> {
     type Output = Self;
 }
-impl<'n, C: Component> SemsHandMade<C> for SvgStaticNodesOwned<'n, C> {
+impl<'n, C: Component> SemsHandMade<'n, C> for SvgStaticNodesOwned<'n, C> {
     type Output = Self;
 }
 
-impl<'h, 'n: 'h, C: Component> SemsForDistinctNames<C> for SvgNodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> SemsForDistinctNames<'n, C> for SvgNodes<'h, 'n, C> {
     type Output = Self;
 }
-impl<'h, 'n: 'h, C: Component> SemsForDistinctNames<C> for SvgStaticNodes<'h, 'n, C> {
+impl<'h, 'n: 'h, C: Component> SemsForDistinctNames<'n, C> for SvgStaticNodes<'h, 'n, C> {
     type Output = Self;
 }
-impl<'n, C: Component> SemsForDistinctNames<C> for SvgNodesOwned<'n, C> {
+impl<'n, C: Component> SemsForDistinctNames<'n, C> for SvgNodesOwned<'n, C> {
     type Output = Self;
 }
-impl<'n, C: Component> SemsForDistinctNames<C> for SvgStaticNodesOwned<'n, C> {
+impl<'n, C: Component> SemsForDistinctNames<'n, C> for SvgStaticNodesOwned<'n, C> {
     type Output = Self;
 }
-impl<'n, C: Component> SemsForDistinctNames<C> for SvgStaticAttributes<'n, C> {
+impl<'n, C: Component> SemsForDistinctNames<'n, C> for SvgStaticAttributes<'n, C> {
     type Output = SvgNodesOwned<'n, C>;
 }
-impl<'n, C: Component> SemsForDistinctNames<C> for SvgElementUpdater<'n, C> {
+impl<'n, C: Component> SemsForDistinctNames<'n, C> for SvgElementUpdater<'n, C> {
     type Output = SvgNodesOwned<'n, C>;
 }
 
@@ -453,7 +459,7 @@ impl<'n, C: Component> SvgStaticNodesOwned<'n, C> {
 }
 
 pub trait MethodsForSvgElementContent<'n, C: Component>:
-    ElementUpdaterMut<C> + Into<SvgNodesOwned<'n, C>> + Into<SvgStaticNodesOwned<'n, C>>
+    ElementUpdaterMut<'n, C> + Into<SvgNodesOwned<'n, C>> + Into<SvgStaticNodesOwned<'n, C>>
 {
     fn update_nodes(self) -> SvgNodesOwned<'n, C> {
         self.into()

--- a/src/render/svg/partial_list.rs
+++ b/src/render/svg/partial_list.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-pub trait SemsForPartialList<'a, C: Component>: Sized + NodesUpdaterMut<C> {
+pub trait SemsForPartialList<'a, C: Component>: Sized + NodesUpdaterMut<'a, C> {
     fn list_with_render<I, II, R>(
         mut self,
         items: II,
@@ -61,5 +61,5 @@ pub trait SemsForPartialList<'a, C: Component>: Sized + NodesUpdaterMut<C> {
 
 impl<'a, C: Component> SemsForPartialList<'a, C> for SvgNodesOwned<'a, C> {}
 impl<'a, C: Component> SemsForPartialList<'a, C> for SvgStaticNodesOwned<'a, C> {}
-impl<'h, 'n: 'h, C: Component> SemsForPartialList<'h, C> for SvgNodes<'h, 'n, C> {}
-impl<'h, 'n: 'h, C: Component> SemsForPartialList<'h, C> for SvgStaticNodes<'h, 'n, C> {}
+impl<'h, 'n: 'h, C: Component> SemsForPartialList<'n, C> for SvgNodes<'h, 'n, C> {}
+impl<'h, 'n: 'h, C: Component> SemsForPartialList<'n, C> for SvgStaticNodes<'h, 'n, C> {}


### PR DESCRIPTION
Hey :wave: the current API of this crate sadly relies on an unsound compiler bug. For now, this bug has been fixed as a lint (https://github.com/rust-lang/rust/issues/105572) which we will soon change to a hard error. While the other crates found via [crater](https://github.com/rust-lang/crater) all had pretty simple and self-contained fixes, `spair` unfortunately depends on this bug in a quite intrusive way. This is not your fault and was caused by [a high priority bug in rustc](https://github.com/rust-lang/rust/issues/105295).

This PR implements probably the best way to solve this issue. What follows is a summary of what's going on together with an explanation of the approach taken in this PR. Feel free to reach out to me by either simply replying on this PR, via email, or using the official Rust zulip chat.

A huge thanks to @BoxyUwU who actually implemented this PR.

## What is the issue

You pretty much have a bunch of the following setup:
```rust
struct XUpdater<'s> {
    fields: &'s String, // dummy field
}

trait XUpdaterMut {
    fn updater_mut<'a>(&'a mut self) -> &'a mut XUpdater<'a>;
}

impl<'s> XUpdaterMut for XUpdater<'s> {
    fn updater_mut<'a>(&'a mut self) -> &'s mut XUpdater<'a> {
        self
    }
}
```
And this definitely makes sense as an API, there's just one small issue: you accidentally got the compiler to incorrectly accept unsound code without any `unsafe`. This sucks and is getting fixed in the compiler.

## Why is this unsound

When checking the body of function we are assuming that its arguments and return type are well-formed, i.e. they are "sensible". This is correct because the caller has to prove that they are.

This is used in the implementation of `updater_mut`. To return a mutable reference to `self` you **must not** change lifetimes in `self`[^1], as it could otherwise get replaced with a new object with these different lifetimes. We do however change the lifetime of `XUpdater` from `'s` to `'a` so that should fail.

However, the type of `&'a mut self` is `&'a mut XUpdater<'s>`, so we can assume that `'s: 'a` holds and the return type is `&'s mut XUpdater<'a>` so we can assume that `'a: 's` holds. This means that `'s` and `'a` are simply equal here.

While this may be surprising, it is completely sound. The issue is that we do not have the requirement `'a: 's` in the trait as there is no way to even name `'s` at that point. When using functions, we check the signature of the trait, not the signature of the method, so at no point do we check `'a: 's` when using `<XUpdater<'s> as XUpdaterMut>::updater_mut`.

For a showcase of how this is unsound, see this [playground example](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=446c66e27e236e9c30a259dcc6e68e50).

## How to fix this issue

You cannot write these impls without the compiler bug. So we have to change the trait definition to properly propagate the right bound to the caller of this method.

```rust
trait XUpdaterMut {
    // How can we name `'s` here, it's a lifetime we only have as
    // a part of the self type?
    fn updater_mut<'a>(&'a mut self) -> &'a mut XUpdater<'s>;
}
```

While there are some other potential approaches to deal with this, the only sensible one we could come up with for now is to name `'s` as an argument of the trait which is what we've done in this PR.
```rust
trait XUpdaterMut<'s> {
    fn updater_mut<'a>(&'a mut self) -> &'a mut XUpdater<'s>;
}
```
This does infect quite a lot of code and also changes your public API. While unfortunate, I expect this to be unavoidable.

[^1]: i.e. the lifetime of the pointee of mutable references is *invariant*. See the [nomicon](https://doc.rust-lang.org/nomicon/subtyping.html#variance) for more details