### PR TITLE
Use TypeId as unique arm identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The following code is extracted from `examples/fetch/src/lib.rs`:
 ```rust
 element
     .match_if(|mi| match self.branch.as_ref() {
-        Some(branch) => spair::set_arm!(mi) // `spair::set_arm!()` use `line!()` internally to set `render_on_arm_index()`
+        Some(branch) => spair::set_arm!(mi) // `spair::set_arm!()` uses a unique identifier internally to set `render_on_arm_index()`
             // Render the content of `Some(branch)`
             .rupdate(branch)
             // some code removed

--- a/src/dom/nodes.rs
+++ b/src/dom/nodes.rs
@@ -1,3 +1,5 @@
+use std::any::TypeId;
+
 #[cfg(feature = "keyed-list")]
 use super::KeyedList;
 use super::{
@@ -334,7 +336,7 @@ impl Nodes {
 }
 
 pub struct GroupedNodes {
-    active_index: Option<u32>,
+    active_index: Option<TypeId>,
     // `end_flag_node` marks the boundary of the end of this group of nodes
     end_flag_node: web_sys::Node,
     nodes: Nodes,
@@ -376,7 +378,7 @@ impl GroupedNodes {
         &self.end_flag_node
     }
 
-    pub fn set_active_index(&mut self, index: u32, parent: &web_sys::Node) -> ElementStatus {
+    pub fn set_active_index(&mut self, index: TypeId, parent: &web_sys::Node) -> ElementStatus {
         if Some(index) != self.active_index {
             self.nodes.clear_and_remove_child_from_dom(parent);
             self.active_index = Some(index);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,9 @@
 #[macro_export]
 macro_rules! set_arm {
-    ( $match_if:ident ) => {
-        $match_if.render_on_arm_index(line!())
+    ( $match_if:ident $(,)? ) => {
+        $match_if.render_on_arm_index({
+            struct Index;
+            ::core::any::TypeId::of::<Index>()
+        })
     };
 }

--- a/src/render/base/nodes.rs
+++ b/src/render/base/nodes.rs
@@ -1,3 +1,5 @@
+use std::any::TypeId;
+
 use super::{ElementUpdater, ListUpdater};
 use crate::{
     component::{Child, Comp, Component},
@@ -215,7 +217,7 @@ impl<'a, C: Component> MatchIfUpdater<'a, C> {
         self.comp.clone()
     }
 
-    pub fn render_on_arm_index(self, index: u32) -> NodesUpdater<'a, C> {
+    pub fn render_on_arm_index(self, index: TypeId) -> NodesUpdater<'a, C> {
         let status = self.grouped_nodes.set_active_index(index, self.parent);
         let (nodes, next_sibling) = self.grouped_nodes.nodes_mut_and_end_flag_node();
 

--- a/src/render/html/nodes.rs
+++ b/src/render/html/nodes.rs
@@ -1,3 +1,5 @@
+use std::any::TypeId;
+
 #[cfg(feature = "queue-render")]
 use wasm_bindgen::UnwrapThrowExt;
 
@@ -571,7 +573,7 @@ impl<'updater, C: Component> HemsForDistinctNames<'updater, C> for StaticAttribu
 pub struct HtmlMatchIfUpdater<'a, C: Component>(MatchIfUpdater<'a, C>);
 
 impl<'a, C: Component> HtmlMatchIfUpdater<'a, C> {
-    pub fn render_on_arm_index(self, index: u32) -> NodesOwned<'a, C> {
+    pub fn render_on_arm_index(self, index: TypeId) -> NodesOwned<'a, C> {
         NodesOwned(HtmlNodesUpdater {
             nodes_updater: self.0.render_on_arm_index(index),
             _select_element_value_manager: None, // How about a match_if inside a <select> element?

--- a/src/render/svg/nodes.rs
+++ b/src/render/svg/nodes.rs
@@ -1,3 +1,5 @@
+use std::any::TypeId;
+
 #[cfg(feature = "queue-render")]
 use wasm_bindgen::UnwrapThrowExt;
 
@@ -531,7 +533,7 @@ impl<'n, C: Component> MethodsForSvgElementContent<'n, C> for SvgStaticAttribute
 pub struct SvgMatchIfUpdater<'a, C: Component>(MatchIfUpdater<'a, C>);
 
 impl<'a, C: Component> SvgMatchIfUpdater<'a, C> {
-    pub fn render_on_arm_index(self, index: u32) -> SvgNodesOwned<'a, C> {
+    pub fn render_on_arm_index(self, index: TypeId) -> SvgNodesOwned<'a, C> {
         SvgNodesOwned::new(self.0.render_on_arm_index(index))
     }
 


### PR DESCRIPTION
Using `line!()` is bound to subtly fail if you write the different cases in the same line. This can happen unnoticedly if it is used e.g. in a macro.

This PR replaces the use of `line!()` with the `TypeId` of an ephemeral type. That ensures that the index is actually unique under all circumstances. `TypeId` is a wrapper around a `u64`, so there should be no drawbacks to this approach.