### PR TITLE
Hide `render_on_arm_index()`

### DIFF
--- a/src/render/base/nodes.rs
+++ b/src/render/base/nodes.rs
@@ -215,6 +215,7 @@ impl<'a, C: Component> MatchIfUpdater<'a, C> {
         self.comp.clone()
     }
 
+    #[doc(hidden)]
     pub fn render_on_arm_index(self, index: u32) -> NodesUpdater<'a, C> {
         let status = self.grouped_nodes.set_active_index(index, self.parent);
         let (nodes, next_sibling) = self.grouped_nodes.nodes_mut_and_end_flag_node();

--- a/src/render/html/nodes.rs
+++ b/src/render/html/nodes.rs
@@ -571,6 +571,7 @@ impl<'updater, C: Component> HemsForDistinctNames<'updater, C> for StaticAttribu
 pub struct HtmlMatchIfUpdater<'a, C: Component>(MatchIfUpdater<'a, C>);
 
 impl<'a, C: Component> HtmlMatchIfUpdater<'a, C> {
+    #[doc(hidden)]
     pub fn render_on_arm_index(self, index: u32) -> NodesOwned<'a, C> {
         NodesOwned(HtmlNodesUpdater {
             nodes_updater: self.0.render_on_arm_index(index),

--- a/src/render/svg/nodes.rs
+++ b/src/render/svg/nodes.rs
@@ -531,6 +531,7 @@ impl<'n, C: Component> MethodsForSvgElementContent<'n, C> for SvgStaticAttribute
 pub struct SvgMatchIfUpdater<'a, C: Component>(MatchIfUpdater<'a, C>);
 
 impl<'a, C: Component> SvgMatchIfUpdater<'a, C> {
+    #[doc(hidden)]
     pub fn render_on_arm_index(self, index: u32) -> SvgNodesOwned<'a, C> {
         SvgNodesOwned::new(self.0.render_on_arm_index(index))
     }


### PR DESCRIPTION
The method should not be used directly. The user should use `set_arm!()` instead.

Resolves #11.